### PR TITLE
fix error: redefinition of ‘skb_frag_off’ in kcompat.h for Ubuntu 18.04 kernel 4.15.0-189-generic

### DIFF
--- a/e1000e-dkms/usr/src/e1000e-3.8.7/src/kcompat.h
+++ b/e1000e-dkms/usr/src/e1000e-3.8.7/src/kcompat.h
@@ -7134,7 +7134,9 @@ devlink_flash_update_status_notify(struct devlink __always_unused *devlink,
 /*****************************************************************************/
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0))
 #if (!(RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,2)) && \
-     !(SLE_VERSION_CODE >= SLE_VERSION(15,2,0)))
+     !(SLE_VERSION_CODE >= SLE_VERSION(15,2,0)) && \
+     !(UBUNTU_VERSION_CODE && LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)))
+
 static inline unsigned int skb_frag_off(const skb_frag_t * frag)
 {
 	return frag->page_offset;
@@ -7147,7 +7149,7 @@ static inline void skb_frag_off_add(skb_frag_t * frag, int delta)
 
 #define __flow_indr_block_cb_register __tc_indr_block_cb_register
 #define __flow_indr_block_cb_unregister __tc_indr_block_cb_unregister
-#endif /* !(RHEL >= 8.2) && !(SLES >= 15sp2) */
+#endif /* !(RHEL >= 8.2) && !(SLES >= 15sp2) && !(UBUNTU >= kernel 4.15.0-157)*/
 #if (SLE_VERSION_CODE >= SLE_VERSION(15,2,0))
 #define HAVE_NDO_XSK_WAKEUP
 #endif /* SLES15sp2 */


### PR DESCRIPTION
prevent duplicated skb_frag_off for Ubuntu 18.04 kernel 4.15.0-189-generic
propose of resolution for issue #12 

tested:
```
root@az:/var/lib/dkms/e1000e/3.8.7/build/src# make
*** The target kernel has CONFIG_MODULE_SIG_ALL enabled, but
*** the signing key cannot be found. Module signing has been
*** disabled for this build.
make[1]: Entering directory '/usr/src/linux-headers-4.15.0-189-generic'
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/netdev.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/ethtool.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/ich8lan.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/mac.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/nvm.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/phy.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/manage.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/80003es2lan.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/82571.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/param.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/ptp.o
  CC [M]  /var/lib/dkms/e1000e/3.8.7/build/src/kcompat.o
  LD [M]  /var/lib/dkms/e1000e/3.8.7/build/src/e1000e.o
  Building modules, stage 2.
  MODPOST 1 modules
  CC      /var/lib/dkms/e1000e/3.8.7/build/src/e1000e.mod.o
  LD [M]  /var/lib/dkms/e1000e/3.8.7/build/src/e1000e.ko
make[1]: Leaving directory '/usr/src/linux-headers-4.15.0-189-generic'
root@az:/var/lib/dkms/e1000e/3.8.7/build/src# uname -a
Linux az 4.15.0-189-generic #200-Ubuntu SMP Wed Jun 22 19:53:37 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```